### PR TITLE
Prh/support rethink 2.2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,13 +33,13 @@ script:
   - sudo apt-get install -y --force-yes mongodb-org=$MONGO_TEST
   - sudo service mongod restart
   - sudo apt-get install -y --force-yes rethinkdb=2.2*
-  - sudo pip install 'rethinkdb<2.3'
   - sudo sed "s/^#\(.*bind.*\)/bind=all/" /etc/rethinkdb/default.conf.sample | sudo tee /etc/rethinkdb/instances.d/instance1.conf
   - sudo service rethinkdb restart
+  - pip install 'rethinkdb<2.3'
   - python setup.py install
   - pytest --capture=no tests
   - sudo apt-get install -y --force-yes rethinkdb
   - sudo service rethinkdb restart
-  - sudo pip install 'rethinkdb~=2.3'
+  - pip install 'rethinkdb~=2.3'
   - python setup.py install
   - pytest --capture=no tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,14 @@ before_script:
 script:
   - sudo apt-get install -y --force-yes mongodb-org=$MONGO_TEST
   - sudo service mongod restart
-  - sudo apt-get install -y --force-yes rethinkdb
+  - sudo apt-get install -y --force-yes rethinkdb=2.2*
+  - sudo pip install 'rethinkdb<2.3'
   - sudo sed "s/^#\(.*bind.*\)/bind=all/" /etc/rethinkdb/default.conf.sample | sudo tee /etc/rethinkdb/instances.d/instance1.conf
   - sudo service rethinkdb restart
+  - python setup.py install
+  - pytest --capture=no tests
+  - sudo apt-get install -y --force-yes rethinkdb
+  - sudo service rethinkdb restart
+  - sudo pip install 'rethinkdb~=2.3'
   - python setup.py install
   - pytest --capture=no tests

--- a/dbloader/loader/loader.py
+++ b/dbloader/loader/loader.py
@@ -25,6 +25,7 @@ class Loader(object):
         self.databases = ['dbl_1', 'dbl_2', 'dbl_3']
         self.tables = ['ltc1', 'ltc2', 'ltc3']
 
+        self.itterations = 1
         self.concurrency = 20
         self.inserts = 100
         self.deletes = 100
@@ -200,10 +201,6 @@ class Loader(object):
         if not self.ready:
             self.create_if_not_exists(self.conn, self.custom)
         results = []
-        if self.custom is not None:
-            for crud in custom:
-                if crud['ctype'] == 'select':
-                    logger.exception('Custom Selects')
 
         pool = Pool(self.concurrency)
         for database in self.databases:

--- a/dbloader/rethink/rethink_loader.py
+++ b/dbloader/rethink/rethink_loader.py
@@ -8,7 +8,6 @@ import rethinkdb as r
 import time
 import loader.loader as l
 import logging
-from multiprocessing import Pool
 
 logger = logging.getLogger(__name__)
 

--- a/dbloader/rethink/rethink_loader.py
+++ b/dbloader/rethink/rethink_loader.py
@@ -8,6 +8,7 @@ import rethinkdb as r
 import time
 import loader.loader as l
 import logging
+from multiprocessing import Pool
 
 logger = logging.getLogger(__name__)
 
@@ -23,14 +24,19 @@ class RethinkLoader(l.Loader):
         '''
         l.Loader.__init__(self)
         self.dbtype = 'RethinkDB'
+        self.version = r.__version__
 
     def get_connection(self, host, port):
         '''
         Get a rethink connection
         '''
         try:
-            r.set_loop_type('gevent')
-            self.conn = r.connect(self.host, self.port)
+            if self.version <= '2.3':
+                old_conn = r.connect(self.host, self.port)
+                return(old_conn)
+            else:
+                r.set_loop_type('gevent')
+                self.conn = r.connect(self.host, self.port)
 
         except Exception:
             logger.exception('Unable to connect to database')
@@ -41,8 +47,12 @@ class RethinkLoader(l.Loader):
         '''
         If the databases or tables do not exist, create them
         '''
-        if self.conn is None:
-            self.conn = self.get_connection()
+        if self.version <= '2.3':
+            conn = self.get_connection(self.host, self.port)
+        else:
+            if self.conn is None:
+                self.conn = self.get_connection(self.host, self.port)
+            conn = self.conn
 
         try:
             if self.custom is not None:
@@ -53,15 +63,17 @@ class RethinkLoader(l.Loader):
                 for table in self.tables:
                     dblist = r.db_list().run(self.conn)
                     if database not in dblist:
-                        r.db_create(database).run(self.conn)
-                        tablist = r.db(database).table_list().run(self.conn)
+                        r.db_create(database).run(conn)
+                        tablist = r.db(database).table_list().run(conn)
                         if table not in tablist:
-                            r.db(database).table_create(table).run(self.conn)
+                            r.db(database).table_create(table).run(conn)
                     else:
-                        tablist = r.db(database).table_list().run(self.conn)
+                        tablist = r.db(database).table_list().run(conn)
                         if table not in tablist:
-                            r.db(database).table_create(table).run(self.conn)
+                            r.db(database).table_create(table).run(conn)
             self.ready = True
+            if self.version <= '2.3':
+                conn.close()
 
         except Exception:
             logger.exception('Unable check and or setup databases/tables')
@@ -77,6 +89,10 @@ class RethinkLoader(l.Loader):
 
         start_time = time.time()
         try:
+            if self.version <= '2.3':
+                conn = self.get_connection(self.host, self.port)
+            else:
+                conn = self.conn
             random_text = self.big_string(100)
             if custom is not None:
                 for crud in custom:
@@ -90,14 +106,16 @@ class RethinkLoader(l.Loader):
                                 rdoc[key] = r.now()
                         database = crud['database']
                         table = crud['table']
-                        result = r.db(database).table(table).insert(rdoc, conflict="update").run(self.conn) 
+                        result = r.db(database).table(table).insert(rdoc, conflict="update").run(conn) 
             else:
                 result = r.db(database).table(table).insert(
                 {"type": "Load Test",
                  "randString": random_text,
                  "created": start_time,
                  "concurrency": 1},
-                conflict="update").run(self.conn)
+                conflict="update").run(conn)
+            if self.version <= '2.3':
+                conn.close()
 
         except Exception:
             logger.exception('Unable to insert a record')
@@ -111,13 +129,19 @@ class RethinkLoader(l.Loader):
 
         start_time = time.time()
         try:
+            if self.version <= '2.3':
+                conn = self.get_connection(self.host, self.port)
+            else:
+                conn = self.conn
             if custom is not None:
                 for crud in custom:
                     if crud['ctype'] == 'delete':
                         records = crud['limit']
-                        result = r.db(database).table(table).limit(records).delete().run(self.conn)
+                        result = r.db(database).table(table).limit(records).delete().run(conn)
             else:
-                result = r.db(database).table(table).limit(1).delete().run(self.conn)
+                result = r.db(database).table(table).limit(1).delete().run(conn)
+            if self.version <= '2.3':
+                conn.close()
 
         except Exception:
             logger.exception('Unable to delete a record')
@@ -131,6 +155,10 @@ class RethinkLoader(l.Loader):
 
         start_time = time.time()
         try:
+            if self.version <= '2.3':
+                conn = self.get_connection(self.host, self.port)
+            else:
+                conn = self.conn
             if custom is not None:
                 for crud in custom:
                     if crud['ctype'] == 'update':
@@ -144,9 +172,11 @@ class RethinkLoader(l.Loader):
                         records = crud['limit']
                         database = crud['database']
                         table = crud['table']
-                        result = r.db(database).table(table).limit(records).update(doc).run(self.conn)
+                        result = r.db(database).table(table).limit(records).update(doc).run(conn)
             else:
-                result = r.db(database).table(table).limit(1).update({'type': 'LTU'}).run(self.conn)
+                result = r.db(database).table(table).limit(1).update({'type': 'LTU'}).run(conn)
+            if self.version <= '2.3':
+                conn.close()
 
         except Exception:
             logger.exception('Unable to update a record')
@@ -160,15 +190,21 @@ class RethinkLoader(l.Loader):
 
         start_time = time.time()
         try:
+            if self.version <= '2.3':
+                conn = self.get_connection(self.host, self.port)
+            else:
+                conn = self.conn
             if custom is not None:
                 for crud in custom:
                     if crud['ctype'] == 'select':
                         records = crud['limit']
                         database = crud['database']
                         table = crud['table']
-                        result = r.db(database).table(table).limit(records).run(self.conn)
+                        result = r.db(database).table(table).limit(records).run(conn)
             else:
-                result = r.db(database).table(table).limit(1).run(self.conn)
+                result = r.db(database).table(table).limit(1).run(conn)
+            if self.version <= '2.3':
+                conn.close()
 
         except Exception:
             logger.exception('Unable to select a record')

--- a/dbloader/rethink_example.py
+++ b/dbloader/rethink_example.py
@@ -1,40 +1,37 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+from gevent import monkey
+monkey.patch_all()
+import json
+import os
+import sys
+import logging
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), './dbloader')))
 import dbloader as dbl
 
+logger = logging.getLogger(__name__)
+
 dbl.setup_logs('./dbloader.log', True)
-ldr = dbl.rl.RethinkLoader()
-ldr.host = 'localhost'
-ldr.port = 28015
-ldr.inserts = 50
-ldr.deletes = 2
-ldr.updates = 2
-ldr.selects = 2
-ldr.concurrency = 5
-ldr.itterations = 5
-ldr.databases = ['rt_db_1', 'rt_db_2']
-ldr.tables = ['ltbl_1', 'ltbl_2']
-ldr.insert_some()
-# ldr.conn = ldr.get_connection(ldr.host, ldr.port)
-# if ldr.create_if_not_exists(ldr.conn):
-#     inserted = ldr.insert_some()
-#     deleted = ldr.delete_some()
-#     dbl.logger.info("Inserted %d records in %4.3f sec for an avg insert time of %4.2f" % (len(inserted),
-#                                                                                       sum(inserted),
-#                                                                                       sum(inserted) / len(inserted)))
-#     dbl.logger.info("Deleted %d records in %4.3f sec for an avg delete time of %4.2f" % ( len(deleted),
-#                                                                                       sum(deleted),
-#                                                                                       sum(deleted) / len(deleted)))
-#     inserted, deleted, updated, selected = ldr.load_run()
-#     dbl.logger.info("Run: Inserted %d in %4.3f sec for an avg insert time of %4.2f" % (len(inserted),
-#                                                                                       sum(inserted),
-#                                                                                       sum(inserted) / len(inserted)))
-#     dbl.logger.info("Run: Deleted %d in %4.3f sec for an avg delete time of %4.2f" % (len(deleted),
-#                                                                                       sum(deleted),
-#                                                                                       sum(deleted) / len(deleted)))
-#     dbl.logger.info("Run: Updated %d in %4.3f sec for an avg update time of %4.2f" % (len(updated),
-#                                                                                       sum(updated),
-#                                                                                       sum(updated) / len(updated)))
-#     dbl.logger.info("Run: Selected %d in %4.3f sec for an avg select time of %4.2f" % (len(selected),
-#                                                                                       sum(selected),
-#                                                                                       sum(selected) / len(selected)))
-# else:
-#    dbl.logger.warning("Could not verify databases/tables")
+options = dbl.load_config('./etc/load.yml')
+if not options:
+    exit(1)
+for server in options['server']:
+    node = server['name']
+    dbtype = server['type']
+    port = server['port']
+    user = server['user']
+    passwd = server['pass']
+    if dbtype == 'rethink':
+        ldr = dbl.rl.RethinkLoader()
+        ldr.host = node
+        ldr.custom = server['custom']
+        ldr.port = server['port']
+        ldr.databases = ['rt_db_1', 'rt_db_2']
+        ldr.tables = ['ltbl_1', 'ltbl_2']
+        ldr.inserts = server.get('inserts', 50)
+        ldr.deletes = server.get('deletes', 5)
+        ldr.updates = server.get('updates', 5)
+        ldr.selects = server.get('selects', 5)
+        ldr.concurrency = 5
+        ldr.itterations = 2
+        dbl.main(dbtype, ldr)

--- a/etc/load.yml
+++ b/etc/load.yml
@@ -1,32 +1,37 @@
 ---
 server:
- - name: daltstrethinkdb01
+ - name: daltstlocalrtdb04
    type: rethink
-   port: 29015
+   port: 28015
    user: none
    pass: none
-   concurrency: 4
-   inserts: 250
-   deletes: 200
+   concurrency: 10
+   inserts: 50
+   selects: 20
+   deletes: 10
+   updates: 10
    custom:
     - insert: >
-              {"collectedAt": "var_created", "contentHash":  "var_random" , "importSource":  "loader", 
-               "locationId":  "5d808100-f171-11e6-a502-9ddd243b9f97" , "rating": 1,
-               "review": "Not once was our room cleaned during the two nights we stayed here, the wifi didnt work, there was no breakfast, we heard everything through the thin walls of our room, and the mattresses were dirty. But other than than it was great :)" , 
-               "reviewId":  "var_random", "source":  "google" , "sourceUrl": "https://maps.google.com/maps?cid=411059227829111713", "timelessHash":  "var_random", 
+              {"collectedAt": "var_created", "contentHash":  "var_random" , "importSource":  "loader",
+               "locationId":  "832ec6a0-4d51-11e7-bcc1-11312293ab63" , "rating": 1,
+               "review": "Working at Moz is so awesome!  We always have crazy fun troubleshooting to do, and there is never a lack of new database systems to experiment with and learn.  You never have to worry about being bored or unchallenged here!",
+               "reviewId":  "var_random", "source":  "google" , "sourceUrl": "https://maps.google.com/maps?cid=411059227829111713", "timelessHash":  "var_random",
                "ts": "var_created", "userId":  "10373591" , "username":  "Sam Kirkman" }
       database: beacon
       table: reviews
-      type: insert
-    - select: limit(10)
+      ctype: insert
+    - select:
+      limit: 10
       database: beacon
       table: reviews
-      type: select
-    - delete: limit(2).delete()
+      ctype: select
+    - delete:
+      limit: 2
       database: beacon
       table: reviews
-      type: delete
-    - update: 'limit(2).update({"type": "Custom LTU"})'
+      ctype: delete
+    - update: {"type": "Custom LTU", "collectedAt": "var_created"}
+      limit: 2
       database: beacon
       table: reviews
-      type: update
+      ctype: update

--- a/etc/travis_load.yml
+++ b/etc/travis_load.yml
@@ -1,17 +1,16 @@
 ---
 server:
-# - name: 127.0.0.1
-#   type: mongo
-#   port: 27017
-#   user: none
-#   pass: none
-#   concurrency: 10
-#   inserts: 50
-#   selects: 20
-#   deletes: 10
-#   updates: 10
-# - name: 127.0.0.1
- - name: daltstlocalrtdb04
+ - name: 127.0.0.1
+   type: mongo
+   port: 27017
+   user: none
+   pass: none
+   concurrency: 10
+   inserts: 50
+   selects: 20
+   deletes: 10
+   updates: 10
+ - name: 127.0.0.1
    type: rethink
    port: 28015
    user: none

--- a/etc/travis_load.yml
+++ b/etc/travis_load.yml
@@ -1,16 +1,17 @@
 ---
 server:
- - name: 127.0.0.1
-   type: mongo
-   port: 27017
-   user: none
-   pass: none
-   concurrency: 10
-   inserts: 50
-   selects: 20
-   deletes: 10
-   updates: 10
- - name: 127.0.0.1
+# - name: 127.0.0.1
+#   type: mongo
+#   port: 27017
+#   user: none
+#   pass: none
+#   concurrency: 10
+#   inserts: 50
+#   selects: 20
+#   deletes: 10
+#   updates: 10
+# - name: 127.0.0.1
+ - name: daltstlocalrtdb04
    type: rethink
    port: 28015
    user: none
@@ -23,15 +24,15 @@ server:
    custom:
     - insert: >
               {"collectedAt": "var_created", "contentHash":  "var_random" , "importSource":  "loader",
-               "locationId":  "5d808100-f171-11e6-a502-9ddd243b9f97" , "rating": 1,
-               "review": "Not once was our room cleaned during the two nights we stayed here, the wifi didnt work, there was no breakfast, we heard everything through the thin walls of our room, and the mattresses were dirty. But other than than it was great :)" ,
+               "locationId":  "832ec6a0-4d51-11e7-bcc1-11312293ab63" , "rating": 1,
+               "review": "Working at Moz is so awesome!  We always have crazy fun troubleshooting to do, and there is never a lack of new database systems to experiment with and learn.  You never have to worry about being bored or unchallenged here!",
                "reviewId":  "var_random", "source":  "google" , "sourceUrl": "https://maps.google.com/maps?cid=411059227829111713", "timelessHash":  "var_random",
                "ts": "var_created", "userId":  "10373591" , "username":  "Sam Kirkman" }
       database: beacon
       table: reviews
       ctype: insert
     - select: 
-      limit: 50
+      limit: 10
       database: beacon
       table: reviews
       ctype: select


### PR DESCRIPTION
Older versions of RethinkDB don't support gevent, so since it's only the connection that's not thread safe, we can check the python client version and use a dedicated connection for every thread if the version is less than 2.3.

- Add tests for old rethink versions
- Update rethink loader example to a working version